### PR TITLE
Injecting myMapBean via constructor

### DIFF
--- a/src/test/java/com/hillert/spring/maps/AutowiredMapInjectionTests.java
+++ b/src/test/java/com/hillert/spring/maps/AutowiredMapInjectionTests.java
@@ -32,9 +32,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class AutowiredMapInjectionTests {
 
+	private final Map<String, Object> myMapBean; // Field has to be final.
+
 	@Autowired
-	@Qualifier("myMapBean")
-	private Map<String, Object> myMapBean;
+	public AutowiredMapInjectionTests(@Qualifier("myMapBean") Map<String, Object> myMapBean) {
+		this.myMapBean = myMapBean;
+	}
 
 	/**
 	 * This test passes correctly.


### PR DESCRIPTION
Hi !
I perfectly understand such changes doesn't fix a problem, but maybe it would be temporary solution for developers.
Or add annotation **@TestInstance(TestInstance.Lifecycle.PER_CLASS)** above the **class AutowiredMapInjectionTests**.

Thanks.